### PR TITLE
Quoting argument to make valid YAML for Symfony v3

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -2,7 +2,7 @@ services:
     ingewikkeld_wrapper.sf1_context_proxy:
         class: Ingewikkeld\WrapperBundle\Proxy\Sf1ContextProxy
         arguments:
-            - @kernel
+            - "@kernel"
             - %wrapper_legacypath%
             - %wrapper_app%
             - %wrapper_env%


### PR DESCRIPTION
## Error & Fix

Tried using this Wrapper Bundle on Symfony v3.1.3. Had an error from Symfony:

```
Error message upon deploying "The reserved indicator "@" cannot start a plain scalar; you need to quote the scalar..." The following edit fixes it.
```

Wrapping it in quotes solved the issue.
## Notes

[New in Symfony 2.8: YAML deprecations](http://symfony.com/blog/new-in-symfony-2-8-yaml-deprecations)

```
According to Yaml specification, unquoted strings cannot start with @, so you must wrap these arguments with single or double quotes.
```
